### PR TITLE
[CEN-961] Insert award winner records for jackpot winners

### DIFF
--- a/src/cstar-cli-core/cstar/cli/core/parser.py
+++ b/src/cstar-cli-core/cstar/cli/core/parser.py
@@ -38,6 +38,12 @@ def parser():
     bpd_award_period.add_argument("--grace-period")
     bpd_award_period.add_argument("--connection-string")
 
+    bpd_award_winner = bpd_parser.add_parser("awardwinner")
+
+    bpd_award_winner.add_argument("--action")
+    bpd_award_winner.add_argument("--award-period")
+    bpd_award_winner.add_argument("--connection-string")
+
     bpd_transaction = bpd_parser.add_parser("citizen")
 
     bpd_transaction.add_argument("--action")

--- a/src/cstar-cli-core/cstar/cli/core/parser.py
+++ b/src/cstar-cli-core/cstar/cli/core/parser.py
@@ -43,6 +43,8 @@ def parser():
     bpd_award_winner.add_argument("--action")
     bpd_award_winner.add_argument("--award-period")
     bpd_award_winner.add_argument("--connection-string")
+    bpd_award_winner.add_argument("--file")
+    bpd_award_winner.add_argument("--commit", action="store_true")
 
     bpd_transaction = bpd_parser.add_parser("citizen")
 

--- a/src/cstar-cli/cstar/cli/bpd/__init__.py
+++ b/src/cstar-cli/cstar/cli/bpd/__init__.py
@@ -1,3 +1,4 @@
 from .awardperiod import Awardperiod
+from .awardwinner import Awardwinner
 from .transaction import Transaction
 from .citizen import Citizen

--- a/src/cstar-cli/cstar/cli/bpd/awardwinner.py
+++ b/src/cstar-cli/cstar/cli/bpd/awardwinner.py
@@ -16,15 +16,12 @@ select
   bc.payoff_instr_s as payoff_instr,
 	1500 as amount_n,
 	CURRENT_TIMESTAMP as insert_date_t,
-	'update_bpd_award_winner' as insert_user_s,
+	'update_bpd_award_winner_supercashback' as insert_user_s,
 	true as enabled_b,
 	bap.aw_period_start_d,
 	bap.aw_period_end_d,
 	1500 as jackpot_n,
-	case
-		when bcr.cashback_n <= bre.period_cashback_max_n then bcr.cashback_n
-		else bre.period_cashback_max_n
-	end as cashback_n,
+	0 as cashback_n,
 	'02' as typology_s,
 	bc.account_holder_cf_s,
 	bc.account_holder_name_s,
@@ -44,8 +41,33 @@ where
 	bcr.award_period_id_n = %(award_period)s
 	and bcr.transaction_n >= bap.trx_volume_min_n
 	and bc.enabled_b = true
-  and bcr.ranking_n <= %(top_n)d;
+  and bcr.ranking_n <= %(top_n)s;
 """
+
+
+UPDATE_BPD_AWARD_WINNER = """
+insert into bpd_citizen.bpd_award_winner(
+	award_period_id_n,
+	fiscal_code_s,
+	payoff_instr_s,
+	amount_n,
+	insert_date_t,
+	insert_user_s,
+	enabled_b,
+	aw_period_start_d,
+	aw_period_end_d,
+	jackpot_n,
+	cashback_n,
+	typology_s,
+	account_holder_cf_s,
+	account_holder_name_s,
+	account_holder_surname_s,
+	check_instr_status_s,
+	technical_account_holder_s,
+	issuer_card_id_s
+)
+""" +  SELECT_BPD_AWARD_WINNER 
+
 
 class Awardwinner() :
   
@@ -67,24 +89,15 @@ class Awardwinner() :
     award_winner_df = pd.read_sql(award_winner_q, self.db_connection)
     print(award_winner_df.to_csv())
 
-  def store_winners(self):
-    award_winner_df = pd.read_csv(self.args.file, sep=';')
-    self._insert_award_winners(award_winner_df)
+  def update_jackpot_winners(self):
+    self.db_cursor = self.db_connection.cursor()
+    update_jackpot_winners_q = self.db_cursor.mogrify(
+      UPDATE_BPD_AWARD_WINNER,
+      {
+        "award_period" : self.args.award_period,
+        "top_n" : 100000,
+      })
 
-  def _insert_award_winners(self, award_winner_df):
-    assert award_winner_df >= 0
-      
-    columns = list(award_winner_df)
-
-    # create VALUES('%s', '%s",...) one '%s' per column
-    values = "VALUES({})".format(",".join(["%s" for _ in columns])) 
-
-    # create INSERT INTO table (columns) VALUES('%s',...)
-    insert = "INSERT INTO {} ({}) {}".format(
-      "bpd_citizen.bpd_award_winner", ",".join(columns), values)
-
-    cursor = self.db_connection.cursor()
-    psycopg2.extras.execute_batch(cursor, insert, award_winner_df.values)
-    if self.args.commit:
-      self.db_connection.commit()
-    cursor.close()
+    self.db_cursor.execute(update_jackpot_winners_q)
+    self.db_connection.commit()
+    self.db_cursor.close()

--- a/src/cstar-cli/cstar/cli/bpd/awardwinner.py
+++ b/src/cstar-cli/cstar/cli/bpd/awardwinner.py
@@ -1,0 +1,18 @@
+import psycopg2
+import psycopg2.extras
+
+import pandas as pd
+import pandas.io.sql as psql
+import random
+from datetime import timedelta, datetime, date
+import string
+from .constants import  CITIZEN_RANKING_EXT_SCHEMA
+
+
+class Awardwinner() :
+  def __init__(self, args): 
+    self.args = args
+    self.db_connection = psycopg2.connect(args.connection_string)
+  
+  def create_winners(self):
+    print("Winners")

--- a/src/cstar-cli/cstar/cli/bpd/awardwinner.py
+++ b/src/cstar-cli/cstar/cli/bpd/awardwinner.py
@@ -9,10 +9,82 @@ import string
 from .constants import  CITIZEN_RANKING_EXT_SCHEMA
 
 
+SELECT_BPD_AWARD_WINNER = """
+select
+  bcr.award_period_id_n,
+  bcr.fiscal_code_c as fiscal_code,
+  bc.payoff_instr_s as payoff_instr,
+	1500 as amount_n,
+	CURRENT_TIMESTAMP as insert_date_t,
+	'update_bpd_award_winner' as insert_user_s,
+	true as enabled_b,
+	bap.aw_period_start_d,
+	bap.aw_period_end_d,
+	1500 as jackpot_n,
+	case
+		when bcr.cashback_n <= bre.period_cashback_max_n then bcr.cashback_n
+		else bre.period_cashback_max_n
+	end as cashback_n,
+	'02' as typology_s,
+	bc.account_holder_cf_s,
+	bc.account_holder_name_s,
+	bc.account_holder_surname_s,
+	bc.check_instr_status_s,
+	bc.technical_account_holder_s,
+	bc.issuer_card_id_s
+from
+	bpd_citizen.bpd_citizen_ranking bcr
+	inner join bpd_citizen.bpd_citizen bc on
+	bcr.fiscal_code_c = bc.fiscal_code_s
+	inner join bpd_award_period.bpd_award_period bap on
+	bcr.award_period_id_n = bap.award_period_id_n
+	inner join bpd_citizen.bpd_ranking_ext bre on
+	bcr.award_period_id_n = bre.award_period_id_n
+where
+	bcr.award_period_id_n = %(award_period)s
+	and bcr.transaction_n >= bap.trx_volume_min_n
+	and bc.enabled_b = true
+  and bcr.ranking_n <= %(top_n)d;
+"""
+
 class Awardwinner() :
+  
   def __init__(self, args): 
     self.args = args
     self.db_connection = psycopg2.connect(args.connection_string)
   
   def create_winners(self):
-    print("Winners")
+    self.db_cursor = self.db_connection.cursor()
+
+    award_winner_q = self.db_cursor.mogrify(
+      SELECT_BPD_AWARD_WINNER,
+      {
+        "award_period" : self.args.award_period,
+        "top_n" : 100000,
+      }
+    )
+
+    award_winner_df = pd.read_sql(award_winner_q, self.db_connection)
+    print(award_winner_df.to_csv())
+
+  def store_winners(self):
+    award_winner_df = pd.read_csv(self.args.file, sep=';')
+    self._insert_award_winners(award_winner_df)
+
+  def _insert_award_winners(self, award_winner_df):
+    assert award_winner_df >= 0
+      
+    columns = list(award_winner_df)
+
+    # create VALUES('%s', '%s",...) one '%s' per column
+    values = "VALUES({})".format(",".join(["%s" for _ in columns])) 
+
+    # create INSERT INTO table (columns) VALUES('%s',...)
+    insert = "INSERT INTO {} ({}) {}".format(
+      "bpd_citizen.bpd_award_winner", ",".join(columns), values)
+
+    cursor = self.db_connection.cursor()
+    psycopg2.extras.execute_batch(cursor, insert, award_winner_df.values)
+    if self.args.commit:
+      self.db_connection.commit()
+    cursor.close()


### PR DESCRIPTION
In order to produce the Consap file for supercashback payments we must insert jackpot winner records on the award_winner table To do so we modified [this stored procedure](https://github.com/pagopa/cstar-infrastructure/blob/2f0e140559aedf29e891309a0b86e5a466089f6b/src/psql/migrations/PROD-CSTAR/bpd/V1__bpd.pre.sql#L473).

The insertion has already been performed successfully.