### PR TITLE
[CEN-963] Update jackpot winners in db by setting file and status

### DIFF
--- a/src/cstar-cli-core/cstar/cli/core/parser.py
+++ b/src/cstar-cli-core/cstar/cli/core/parser.py
@@ -44,6 +44,7 @@ def parser():
     bpd_award_winner.add_argument("--award-period")
     bpd_award_winner.add_argument("--connection-string")
     bpd_award_winner.add_argument("--file")
+    bpd_award_winner.add_argument("--chunk-file-name")
     bpd_award_winner.add_argument("--commit", action="store_true")
 
     bpd_transaction = bpd_parser.add_parser("citizen")


### PR DESCRIPTION
## Description
After sending file with jackpot winners to do wire transfers, their position must be updated in DB by setting `chunk_filename_s` (the name of the file used to send their position to consap) and `status_s`. This PR proposes a new `cli` command, based on an update query, to execute the job.