### PR TITLE
[CEN-1003] Rename 'extend_grace_period' to 'set_grace_period'

### DIFF
--- a/src/cstar-cli/cstar/cli/bpd/awardperiod.py
+++ b/src/cstar-cli/cstar/cli/bpd/awardperiod.py
@@ -14,7 +14,7 @@ class Awardperiod() :
     self.args = args
     self.db_connection = psycopg2.connect(args.connection_string)
   
-  def extend_grace_period(self):
+  def set_grace_period(self):
     table = "bpd_award_period.bpd_award_period"
     set_values = "aw_grace_period_n = (%s)"
     conditions = "award_period_id_n = (%s)"


### PR DESCRIPTION
This PR proposes to rename the BPD method 'extend_grace_period' to 'set_grace_period' since the command already allows to either extend or reduce the grace period for a given award period.