### PR TITLE
[CEN-1003] Fix cursor instantiation strategy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,4 +132,6 @@ dmypy.json
 *.xlsx
 *.zip
 *.key
+*.pgp
+*.sha256sum
 .DS_Store

--- a/src/cstar-cli/cstar/cli/bpd/awardperiod.py
+++ b/src/cstar-cli/cstar/cli/bpd/awardperiod.py
@@ -21,9 +21,10 @@ class Awardperiod() :
     update_q = "UPDATE {} SET {} WHERE {};".format(
          table, set_values, conditions)
 
-    self.db_connection.cursor().execute(update_q, [self.args.grace_period, self.args.id])
+    cursor = self.db_connection.cursor()
+    cursor.execute(update_q, [self.args.grace_period, self.args.id])
     self.db_connection.commit()
-    self.db_connection.cursor().close()
+    cursor.close()
   
   def set_properties(self):
     


### PR DESCRIPTION
## Description
When the method `self.db_connection.cursor()` is called a new cursor is returned, but we want to close the same cursor we used to execute the update.