### PR TITLE
[CEN-1087] add method to enroll payment instruments from CSV file

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,17 @@ poetry shell
 If is the first time or changes have been made to the codebase install the packages:
 
 ```bash
-pip install src/cstar-cli-core
-pip install src/cstar-cli
+./install.sh
 ```
 
 Now the cstar CLI is available as _cst_ command:
 
 ```bash
-$ cst
-usage: __main__.py [-h] {fa,bpd} ...
-__main__.py: error: the following arguments are required: subsystem
+cst <VERTICAL> <DOMAIN> --action <ACTION> [COMMAND PARAMETERS ...]
+```
+
+Example(s):
+
+```bash
+cst bpd paymentinstrument --action enroll --connection-string <CONNSTR> --file <INPUT_FILE>
 ```

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,4 @@
+# Make sure to run this command inside a Poetry shell
+
+pip install --force-reinstall src/cstar-cli-core
+pip install --no-deps --force-reinstall src/cstar-cli

--- a/src/cstar-cli-core/cstar/cli/core/parser.py
+++ b/src/cstar-cli-core/cstar/cli/core/parser.py
@@ -8,16 +8,7 @@ def parser():
 
     subsystem_parser.add_parser("fa")
 
-    # FA commands
-    # fa_parser.add_argument("intermediate")
-    # fa_parser.add_argument("pem-csr-file", type=argparse.FileType('r'))
-    # fa_parser.add_argument("--ttl", metavar="ttl")
-    # fa_parser.add_argument("--send-email", action="store_true")
-    # fa_parser.add_argument("--no-confirm", action="store_true")
-    #sign_parser.set_defaults(call=client_sign)
-
     bpd_parser = subsystem_parser.add_parser("bpd").add_subparsers(dest="command")
-
 
     bpd_transaction = bpd_parser.add_parser("transaction")
 
@@ -56,10 +47,10 @@ def parser():
     bpd_transaction.add_argument("--award-period")
     bpd_transaction.add_argument("--file")
 
+    bpd_payment_instrument = bpd_parser.add_parser("paymentinstrument")
 
-    #revoke_parser.set_defaults(call=client_revoke)
+    bpd_payment_instrument.add_argument("--action")
+    bpd_payment_instrument.add_argument("--file")
+    bpd_payment_instrument.add_argument("--connection-string")
 
     return argparser
-
-
-

--- a/src/cstar-cli/cstar/cli/bpd/__init__.py
+++ b/src/cstar-cli/cstar/cli/bpd/__init__.py
@@ -2,3 +2,4 @@ from .awardperiod import Awardperiod
 from .awardwinner import Awardwinner
 from .transaction import Transaction
 from .citizen import Citizen
+from .paymentinstrument import Paymentinstrument

--- a/src/cstar-cli/cstar/cli/bpd/paymentinstrument.py
+++ b/src/cstar-cli/cstar/cli/bpd/paymentinstrument.py
@@ -1,0 +1,56 @@
+import psycopg2
+import pandas as pd
+import uuid
+
+
+class Paymentinstrument():
+
+  def __init__(self, args):
+    self.args = args
+    self.db_connection = psycopg2.connect(args.connection_string)
+  
+  def enroll(self):
+    
+    payment_instruments_df = pd.read_csv(self.args.file, sep=';')
+    if payment_instruments_df.shape[1] != 4:
+      raise ValueError(f"Invalid number of column in input file (expected 4, found {payment_instruments_df.shape[1]})")
+
+    insert_id = uuid.uuid4()
+
+    cursor = self.db_connection.cursor()
+
+    for index, row in payment_instruments_df.iterrows():
+
+      print(f"Processing row {index}")
+
+      insert_payment_instrument_q = cursor.mogrify(
+        "INSERT INTO bpd_payment_instrument.bpd_payment_instrument "
+        "  (hpan_s, fiscal_code_s, enrollment_t, status_c, insert_user_s) "
+        "VALUES (%(hpan)s, %(fiscal_code)s, %(enrollment)s, 'ACTIVE', %(insert_user)s)",
+        {
+          "hpan": row.hpan,
+          "fiscal_code": row.fiscal_code,
+          "enrollment": row.enrollment,
+          "insert_user": str(insert_id)
+        }
+      )
+
+      print(f"Executing query: {insert_payment_instrument_q}")
+      cursor.execute(insert_payment_instrument_q)
+
+      insert_payment_instrument_history_q = cursor.mogrify(
+        "INSERT INTO bpd_payment_instrument.bpd_payment_instrument_history "
+        "  (hpan_s, activation_t, insert_user_s)"
+        "VALUES (%(hpan)s, %(activation)s, %(insert_user)s)",
+        {
+          "hpan": row.hpan,
+          "activation": row.activation,
+          "insert_user": str(insert_id)
+        }
+      )
+
+      print(f"Executing query: {insert_payment_instrument_history_q}")
+      cursor.execute(insert_payment_instrument_history_q)
+    
+    self.db_connection.commit()
+    cursor.close()


### PR DESCRIPTION
This PR proposes to add a paymentinstrument module under the bpd vertical, with a action named 'enroll' which allows the bulk insertion of payment methods for testing purposes.