### PR TITLE
[TAE-35] AdE result files tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,3 +85,21 @@ cst tae transactionaggregate --action aggregate_transactions --aggr-qty 9000 --r
 ```bash
 cst tae transactionaggregate --action aggregate_transactions --aggr-qty 9000 --revers-ratio 100 --ratio-no-pos-type 30 --ratio-no-vat 20 --shuffle --out-dir /tmp --pgp --key ~/certificates/public.key
 ```
+
+### Creating synthetic acks like the ones sent by AdE to CSTAR, according to the interface agreement.
+
+#### Unzipped
+```bash
+cst tae results --action synthetic_results --res-qty 100
+```
+#### Zipped
+
+```bash
+cst tae results --action synthetic_results --res-qty 100 --gzip
+```
+
+### Creating synthetic wrong record reports like the ones sent by Cstar to senders.
+
+```bash
+cst tae registryreports --action synthetic_reports --rep-qty 100
+```

--- a/src/cstar-cli-core/cstar/cli/core/parser.py
+++ b/src/cstar-cli-core/cstar/cli/core/parser.py
@@ -53,6 +53,8 @@ def parser():
     bpd_payment_instrument.add_argument("--file")
     bpd_payment_instrument.add_argument("--connection-string")
 
+###
+
     rtd_parser = subsystem_parser.add_parser("rtd").add_subparsers(dest="command")
 
     rtd_transaction_filter = rtd_parser.add_parser("transactionfilter")
@@ -70,6 +72,8 @@ def parser():
     rtd_transaction_filter.add_argument("-o", "--out-dir", type=str, default=".")
     rtd_transaction_filter.add_argument("--key", type=str, default="./public.key")
 
+###
+
     tae_parser = subsystem_parser.add_parser("tae").add_subparsers(dest="command")
 
     tae_transaction_aggregate = tae_parser.add_parser("transactionaggregate")
@@ -84,5 +88,19 @@ def parser():
     tae_transaction_aggregate.add_argument("--ratio-no-pos-type", type=int)
     tae_transaction_aggregate.add_argument("--ratio-no-vat", type=int)
     tae_transaction_aggregate.add_argument("--key", type=str, default="./public.key")
+
+    tae_results = tae_parser.add_parser("results")
+
+    tae_results.add_argument("--action")
+    tae_results.add_argument("--res-qty", type=int)
+    tae_results.add_argument("-o", "--out-dir", type=str, default=".")
+    tae_results.add_argument("--gzip", action="store_true")
+
+    tae_results = tae_parser.add_parser("registryreports")
+
+    tae_results.add_argument("--action")
+    tae_results.add_argument("--rep-qty", type=int)
+    tae_results.add_argument("--acquirer", default=99999)
+    tae_results.add_argument("-o", "--out-dir", type=str, default=".")
 
     return argparser

--- a/src/cstar-cli/cstar/cli/tae/__init__.py
+++ b/src/cstar-cli/cstar/cli/tae/__init__.py
@@ -1,1 +1,3 @@
 from .transactionaggregates import Transactionaggregate
+from .results import Results
+from .registryreports import Registryreports

--- a/src/cstar-cli/cstar/cli/tae/registryreports.py
+++ b/src/cstar-cli/cstar/cli/tae/registryreports.py
@@ -4,9 +4,7 @@ import pandas as pd
 import os
 from datetime import datetime
 
-
 CSV_SEPARATOR = ";"
-
 
 APPLICATION_PREFIX_FILE_NAME = "CSTAR"
 ADE_ACK_FIXED_SEGMENT = "ADEACK"
@@ -14,6 +12,8 @@ RESULTS_FILE_EXTENSION = ".csv"
 ZIPPED_FILE_EXTENSION = ".gzip"
 
 ACQUIRER_CODE = "99999"
+PERSON_NATURAL_LEGAL_RATIO = 3
+
 
 class Registryreports:
     """Utilities related to the rtd-ms-transaction-filter service, a.k.a. Batch Acquirer"""
@@ -36,19 +36,22 @@ class Registryreports:
         reports = []
 
         for i in range(self.args.rep_qty):
-
             reports.append(
                 [
                     sha256(f"{'terminal_id'}{i}".encode()).hexdigest(),
-                    sha256(f"{'merchant_id'}{i}".encode()).hexdigest()
+                    sha256(f"{'merchant_id'}{i}".encode()).hexdigest(),
+                    "CF" + str(i).zfill(15 - len(str(i))) if i % PERSON_NATURAL_LEGAL_RATIO == 0 else "PI" + str(
+                        i).zfill(10 - len(str(i)))
                 ])
 
         columns = [
             "terminal_id",
-            "merchant_id"
+            "merchant_id",
+            "anagrafica"
         ]
         reports_df = pd.DataFrame(reports, columns=columns)
-        reports_df_path = self.args.out_dir + "/" + APPLICATION_PREFIX_FILE_NAME + "." + str(self.args.acquirer) + "." + ADE_ACK_FIXED_SEGMENT + "." + datetime.today().strftime(
+        reports_df_path = self.args.out_dir + "/" + APPLICATION_PREFIX_FILE_NAME + "." + str(
+            self.args.acquirer) + "." + ADE_ACK_FIXED_SEGMENT + "." + datetime.today().strftime(
             '%Y%m%d.%H%M%S') + ".001" + RESULTS_FILE_EXTENSION
 
         os.makedirs(os.path.dirname(reports_df_path), exist_ok=True)

--- a/src/cstar-cli/cstar/cli/tae/registryreports.py
+++ b/src/cstar-cli/cstar/cli/tae/registryreports.py
@@ -1,0 +1,59 @@
+from hashlib import sha256
+
+import pandas as pd
+import os
+from datetime import datetime
+
+
+CSV_SEPARATOR = ";"
+
+
+APPLICATION_PREFIX_FILE_NAME = "CSTAR"
+ADE_ACK_FIXED_SEGMENT = "ADEACK"
+RESULTS_FILE_EXTENSION = ".csv"
+ZIPPED_FILE_EXTENSION = ".gzip"
+
+ACQUIRER_CODE = "99999"
+
+class Registryreports:
+    """Utilities related to the rtd-ms-transaction-filter service, a.k.a. Batch Acquirer"""
+
+    def __init__(self, args):
+        self.args = args
+
+    def synthetic_reports(self):
+        """Produces a synthetic version of the CSV file produced by the acquirers for RTD
+
+        Parameters:
+            --res-qty: the number of results generated
+            -o, --out-dir: path to the directory where the file will be created, default is "."
+            --acquirer: ABI of the sender, default is "99999"
+        """
+
+        if not self.args.rep_qty:
+            raise ValueError("--res-qty is mandatory")
+
+        reports = []
+
+        for i in range(self.args.rep_qty):
+
+            reports.append(
+                [
+                    sha256(f"{'terminal_id'}{i}".encode()).hexdigest(),
+                    sha256(f"{'merchant_id'}{i}".encode()).hexdigest()
+                ])
+
+        columns = [
+            "terminal_id",
+            "merchant_id"
+        ]
+        reports_df = pd.DataFrame(reports, columns=columns)
+        reports_df_path = self.args.out_dir + "/" + APPLICATION_PREFIX_FILE_NAME + "." + str(self.args.acquirer) + "." + ADE_ACK_FIXED_SEGMENT + "." + datetime.today().strftime(
+            '%Y%m%d.%H%M%S') + ".001" + RESULTS_FILE_EXTENSION
+
+        os.makedirs(os.path.dirname(reports_df_path), exist_ok=True)
+
+        with open(reports_df_path, "a") as f:
+            f.write(reports_df.to_csv(index=False, header=False, sep=CSV_SEPARATOR))
+
+        print("Done")

--- a/src/cstar-cli/cstar/cli/tae/results.py
+++ b/src/cstar-cli/cstar/cli/tae/results.py
@@ -1,0 +1,136 @@
+import gzip
+from hashlib import sha256
+import random
+
+import pandas as pd
+import os
+from datetime import datetime
+
+CSV_SEPARATOR = ";"
+
+APPLICATION_PREFIX_FILE_NAME = "CSTAR"
+ADE_ACK_FIXED_SEGMENT = "ADEACK"
+RESULTS_FILE_EXTENSION = ".csv"
+ZIPPED_FILE_EXTENSION = ".gzip"
+
+ACQUIRER_CODE = "99999"
+
+SCARTI = [
+    ['0101',
+     '0104',
+     '0105'],
+
+    ['0204',
+     '0205'],
+
+    ['0304',
+     '0305'],
+
+    ['0403'
+     '0404',
+     '0405'],
+
+    ['0502',
+     '0504',
+     '0505'],
+
+    ['0604',
+     '0605'],
+
+    ['0704',
+     '0705'],
+
+    ['0804',
+     '0805'],
+
+    ['0904',
+     '0905'],
+
+    ['1004',
+     '1005'],
+
+    ['1104',
+     '1105'],
+
+    ['1204',
+     '1205',
+     '1206'],
+
+    ['1304'],
+
+    ['1404',
+     '1405']
+]
+
+SEGNALAZIONI = [
+    ['1201',
+     '1204'],
+
+    ['1302',
+     '1303',
+     '1304'],
+
+]
+
+
+class Results:
+    """Utilities related to the rtd-ms-transaction-filter service, a.k.a. Batch Acquirer"""
+
+    def __init__(self, args):
+        self.args = args
+
+    def synthetic_results(self):
+        """Produces a synthetic version of the CSV file produced by the acquirers for RTD
+
+        Parameters:
+            --res-qty: the number of results generated
+            -o, --out-dir: path to the directory where the file will be created, default is "."
+            --gzip: if set, also a gzipped version of the file is created
+        """
+
+        if not self.args.res_qty:
+            raise ValueError("--res-qty is mandatory")
+
+        results = []
+
+        for i in range(self.args.res_qty):
+
+            lista_errori = ''
+
+            esito = random.randint(1, 4)
+            match esito:
+                case 2:
+                    for bad_field in random.sample(SCARTI, random.randint(1, 13)):
+                        lista_errori = lista_errori + random.choice(bad_field) + '|'
+                case 4:
+                    for bad_field in random.sample(SCARTI, random.randint(1, 13)):
+                        lista_errori = lista_errori + random.choice(bad_field) + '|'
+                case _:
+                    pass
+
+            results.append(
+                [
+                    sha256(f"{i}{'MYSALT'}".encode()).hexdigest(),
+                    esito,
+                    lista_errori
+                ])
+
+        columns = [
+            "record_id",
+            "esito",
+            "lista_errori"
+        ]
+        results_df = pd.DataFrame(results, columns=columns)
+        results_df_path = self.args.out_dir + "/" + APPLICATION_PREFIX_FILE_NAME + "." + ADE_ACK_FIXED_SEGMENT + "." + datetime.today().strftime(
+            '%Y%m%d.%H%M%S') + ".001" + RESULTS_FILE_EXTENSION
+
+        os.makedirs(os.path.dirname(results_df_path), exist_ok=True)
+
+        with open(results_df_path, "a") as f:
+            f.write(results_df.to_csv(index=False, header=False, sep=CSV_SEPARATOR))
+
+        if self.args.gzip:
+            with gzip.open(results_df_path + ZIPPED_FILE_EXTENSION, "wb") as f:
+                f.write(bytes(results_df.to_csv(index=False, header=False, sep=CSV_SEPARATOR), encoding='utf-8'))
+
+        print("Done")

--- a/src/cstar-cli/cstar/cli/tae/results.py
+++ b/src/cstar-cli/cstar/cli/tae/results.py
@@ -97,7 +97,7 @@ class Results:
 
             lista_errori = ''
 
-            esito = random.randint(1, 4)
+            esito = random.randint(0, 4)
             match esito:
                 case 2:
                     for bad_field in random.sample(SCARTI, random.randint(1, 13)):

--- a/src/cstar-cli/cstar/cli/tae/results.py
+++ b/src/cstar-cli/cstar/cli/tae/results.py
@@ -100,10 +100,10 @@ class Results:
             esito = random.randint(0, 4)
             match esito:
                 case 2:
-                    for bad_field in random.sample(SCARTI, random.randint(1, 13)):
+                    for bad_field in random.sample(SCARTI, random.randint(1, 14)):
                         lista_errori = lista_errori + random.choice(bad_field) + '|'
                 case 4:
-                    for bad_field in random.sample(SCARTI, random.randint(1, 13)):
+                    for bad_field in random.sample(SEGNALAZIONI, random.randint(1, 2)):
                         lista_errori = lista_errori + random.choice(bad_field) + '|'
                 case _:
                     pass


### PR DESCRIPTION
This PR propose the addition of 2 new tools to the CLI of CSTAR.

1. A command to generate results like the ones that will be sent from AdE. Results generated are compliant with the interface agreement.
2. A command to generate reports like the ones that CSTAR will send to the acquirers. Reports generated will contain the couple (terminal_id;merchant_id).

Contained values are completely random and are only for testing purposes.
