### PR TITLE
[RTD-276] Remove download CLI from script

### DIFF
--- a/integration_check/install_Python3.9_and_Poetry.sh
+++ b/integration_check/install_Python3.9_and_Poetry.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-apt-get install -y software-properties-common python3-distutils
 apt-get update
+apt-get install -y software-properties-common python3-distutils
 add-apt-repository -y ppa:deadsnakes/ppa
 echo "8 41" | apt install -yq python3.9
 apt-get install -y python3.9-distutils

--- a/integration_check/install_Python3.9_and_Poetry.sh
+++ b/integration_check/install_Python3.9_and_Poetry.sh
@@ -1,11 +1,9 @@
 #!/bin/sh
 
-apt-get install -y unzip software-properties-common python3-distutils
+apt-get install -y software-properties-common python3-distutils
 apt-get update
 add-apt-repository -y ppa:deadsnakes/ppa
 echo "8 41" | apt install -yq python3.9
 apt-get install -y python3.9-distutils
-wget -O ./cstar-cli.zip https://github.com/pagopa/cstar-cli/archive/refs/heads/main.zip
-unzip cstar-cli.zip
 wget https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
 echo "y" | python3.9 get-poetry.py


### PR DESCRIPTION
#### Description
<!--- Please always add a PR description as if nobody knows anything about the context these changes come from. -->
<!--- Even if we are all from our internal team, we may not be on the same page. -->
<!--- Write this PR as you were contributing to a public OSS project, where nobody knows you and you have to earn their trust. -->
<!--- This will improve our projects in the long run! Thanks. -->
This PR proposes to remove the download of the CLI itself, leaving just the commands to obtain pyhton and poetry.

#### List of Changes
<!--- Describe your changes in detail -->
- change to the script

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because we assume that the installation step of python is done once the cli is already present.

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
- [ ] Unit Test Suite
- [ ] Integration Test Suite
- [ ] Api Tests
- [ ] Load Tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.